### PR TITLE
Add SVG-Plugin for IOS 

### DIFF
--- a/papyros-calculator.pro
+++ b/papyros-calculator.pro
@@ -1,6 +1,10 @@
 QT += quick qml
 QT += widgets
 
+QT += svg
+QTPLUGIN += qsvg
+
+
 SOURCES += src/main.cpp
 
 OTHER_FILES = README.md


### PR DESCRIPTION
Add the SVG support for the ios platform otherwise the simulator throw some not found errors for the icons 